### PR TITLE
#165430840  API endpoint to view list of user accounts 

### DIFF
--- a/server/controllers/accountCtrl.js
+++ b/server/controllers/accountCtrl.js
@@ -95,6 +95,19 @@ class AccountCtrl {
       return next(err);
     }
   }
+
+  static async getUserAccounts(req, res, next) {
+    try {
+      const { id } = await _.cloneDeep(userModel.findEmail(req.params.email));
+      const account = await _.cloneDeep(accountModel.findAccountsById(id));
+      return res.status(200).json({
+        status: res.statusCode,
+        accounts: account
+      });
+    } catch (err) {
+      return next(err);
+    }
+  }
 }
 
 

--- a/server/models/accounts.js
+++ b/server/models/accounts.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import _ from 'lodash';
 import genAccountNo from '../utils/genAccountNo';
 // import transactions from './transactions';
 
@@ -20,6 +21,10 @@ class Accounts {
     };
     this.accounts.push(account);
     return account;
+  }
+
+  findAccountsById(id) {
+    return this.accounts.filter(acct => acct.owner === id).map(acct => _.omit(acct, ['id', 'owner', 'updatedOn']));
   }
 
   findAccountById(id) {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -30,5 +30,7 @@ router.get('/transactions/:transactionId', verifyAuthToken, transaction.getSingl
 
 router.get('/accounts/:accountNumber', verifyAuthToken, accountController.getAccountDetails);
 
+router.get('/user/:email/accounts', verifyAuthToken, authorize.staff, accountController.getUserAccounts);
+
 
 export default router;

--- a/tests/06_others.spec.js
+++ b/tests/06_others.spec.js
@@ -256,3 +256,30 @@ describe('Get Route', () => {
     });
   });
 });
+
+
+// Admin/Staff can View List of accounts of a specific user
+describe('Get Route', () => {
+  describe('GET /api/v1/user/<email-address>/accounts', () => {
+    describe('Admin/Staff can view list of accounts owned by a user', () => {
+      it('should respond with error 401 - unauthorized - if token is invalid or expired', async () => {
+        const res = await chai.request(app).get(`/api/v1/user/${resp.body.data.email}/accounts`).set('Authorization', 'eyJhbGciOiJIUzI1NiIsIkpXVCJ9.kcvIkS9ACezPO2DgAi-XvEikLy9ZA2y0kWiQ');
+        expect(res).to.have.status(401);
+        expect(res.body).to.have.property('error').to.deep.equal('Invalid Token');
+      });
+
+      it('should send unauthorized message if unathorized user tries to get list of accounts', async () => {
+        const res = await chai.request(app).get(`/api/v1/user/${resp.body.data.email}/accounts`).set('Authorization', userToken);
+        expect(res).to.have.status(403);
+        expect(res.body).to.have.property('error').to.deep.equal('Unauthorized');
+      });
+
+      it('should respond with 200 status code if request by the admin/staff for user account is successful', async () => {
+        const res = await chai.request(app).get(`/api/v1/user/${resp.body.data.email}/accounts`).set('Authorization', adminToken);
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.property('accounts');
+        expect(res.body.accounts).to.be.an('array');
+      });
+    });
+  });
+});


### PR DESCRIPTION
**What does this PR do?**
Adds function to view accounts of a specific user. Only accessible to admin and staff. 

**How Has This Been Tested?**
Unit Testing with Mocha

**Description of Task to be completed?**
Have below endpoint working
> GET /user/< user-email-address >/accounts

**How should it be manually tested?**
- Clone the repo and checkout to ft-list-user-accounts-API-165430840
- Run 'npm start', and Use postman or any API testing software to test the above API endpoint
- Add authentication token
key: _Authorization_ Value: _JWT token_


**Pivotal Tracker Story**
> #165430840